### PR TITLE
Load env variables for Threads runner

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+IG_USER=your_username
+IG_PASS=your_password

--- a/runners/threads.js
+++ b/runners/threads.js
@@ -1,4 +1,5 @@
 // runners/threads.js
+import "dotenv/config";
 import fs from "node:fs";
 import path from "node:path";
 import { launchBrowser, newPageWithCookies, persistAndClose } from "../core/browser.js";


### PR DESCRIPTION
## Summary
- Load environment variables in `runners/threads.js` via `dotenv/config`
- Provide `.env` file with IG credentials placeholders so `ensureThreadsReady` can read them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b59c1712d08332b4dc642375d5b966