### PR TITLE
Add unit tests for utilities and test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "scripts": {
         "post": "node postThreads.js",
         "post:headless": "HEADLESS=1 node postThreads.js",
-        "test:content": "node contentProvider.js --prompt \"Зроби короткий бізнес-інсайт українською\""
+        "test:content": "node contentProvider.js --prompt \"Зроби короткий бізнес-інсайт українською\"",
+        "test": "node --test"
     },
     "dependencies": {
         "dotenv": "^16.6.1",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randInt, shuffle, nap, logStepAsync } from '../utils.js';
+import { test } from 'node:test';
+
+test('randInt returns value within inclusive range', () => {
+  for (let i = 0; i < 100; i++) {
+    const val = randInt(1, 5);
+    assert.ok(val >= 1 && val <= 5);
+  }
+});
+
+test('shuffle returns array with same elements', () => {
+  const arr = [1, 2, 3, 4];
+  const shuffled = shuffle([...arr]);
+  assert.equal(shuffled.length, arr.length);
+  assert.deepEqual([...shuffled].sort(), [...arr].sort());
+});
+
+test('nap waits at least the specified time', async () => {
+  const start = Date.now();
+  await nap(50);
+  assert.ok(Date.now() - start >= 45);
+});
+
+test('logStepAsync writes messages to logs/steps.log', async () => {
+  const logPath = path.resolve('logs/steps.log');
+  await fs.rm(path.dirname(logPath), { recursive: true, force: true });
+  await logStepAsync('test message');
+  const content = await fs.readFile(logPath, 'utf8');
+  assert.match(content, /test message/);
+});


### PR DESCRIPTION
## Summary
- add Node test runner script to package.json
- create tests for utilities: randInt, shuffle, nap, logStepAsync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0da77fc8332bfb4216f9580f00d