### PR TITLE
Rename login helper and update imports

### DIFF
--- a/actions/feed.engage.js
+++ b/actions/feed.engage.js
@@ -1,5 +1,5 @@
 // actions/feed.engage.js
-import { ensureThreadsReady } from '../core/login.js';
+import { login } from '../core/login.js';
 import { scrollAndReact } from '../core/feed.js';
 import { BUSINESS_SEARCH_KEYWORDS } from '../coach_prompts/prompts.js';
 
@@ -17,7 +17,7 @@ export async function run(page, {
     timeout = 25000,
     IG_USER = 'ol.matsuk',
 } = {}) {
-    await ensureThreadsReady(page, timeout, { IG_USER });
+    await login(page, { user: IG_USER });
     const res = await scrollAndReact(page, { rounds, pause, keywords, doLike, doComment, commentText });
     return { ok: true, ...res };
 }

--- a/actions/post.write.js
+++ b/actions/post.write.js
@@ -1,5 +1,5 @@
 // actions/post.write.js
-import { ensureThreadsReady } from '../core/login.js';
+import { login } from '../core/login.js';
 import { openComposer, fillAndPost } from '../core/composer.js';
 import { buildPromptForType, MAX_CHARS } from '../coach_prompts/prompts.js';
 
@@ -21,7 +21,7 @@ export async function run(page, {
     image = null
 } = {}) {
     // 1) гарантуємо Threads
-    await ensureThreadsReady(page, timeout, { IG_USER });
+    await login(page, { user: IG_USER });
 
     // 2) відкриваємо композер
     await openComposer(page, timeout);

--- a/actions/search.follow.js
+++ b/actions/search.follow.js
@@ -1,5 +1,5 @@
 // actions/search.follow.js
-import { ensureThreadsReady } from '../core/login.js';
+import { login } from '../core/login.js';
 import { waitForAny, clickAny } from '../utils.js';
 
 /**
@@ -19,7 +19,7 @@ export async function run(page, {
     timeout = 25000,
     IG_USER = 'ol.matsuk'
 } = {}) {
-    await ensureThreadsReady(page, timeout, { IG_USER });
+    await login(page, { user: IG_USER });
 
     // Відкриваємо пошук
     await clickAny(page, [

--- a/core/login.js
+++ b/core/login.js
@@ -190,7 +190,7 @@ async function clickContinueWithInstagramOnLogin(page) {
     await takeShot(page, "after_click_sso");
 }
 
-export async function ensureThreadsReady(page, opts = {}) {
+export async function login(page, opts = {}) {
     const { user: igUser, pass } = getIgCreds();
     const wantedUser = opts.user || igUser || process.env.THREADS_USER || "ol.matsuk";
 
@@ -317,5 +317,5 @@ export async function ensureThreadsReady(page, opts = {}) {
 }
 
 export default {
-    "login.test": async ({ page, user }) => ensureThreadsReady(page, { user }),
+    "login.test": async ({ page, user }) => login(page, { user }),
 };

--- a/runners/threads.js
+++ b/runners/threads.js
@@ -3,7 +3,7 @@ import "dotenv/config";
 import fs from "node:fs";
 import path from "node:path";
 import { launchBrowser, newPageWithCookies, persistAndClose } from "../core/browser.js";
-import { ensureThreadsReady } from "../core/login.js";
+import { login } from "../core/login.js";
 
 function logStep(m) {
     const line = `[${new Date().toISOString()}][runner][step] ${m}\n`;
@@ -45,7 +45,7 @@ async function main() {
         if (action !== "login.test") throw new Error(`Unknown --action=${action}`);
 
         logStep("Запуск дії login.test");
-        await ensureThreadsReady(page, {
+        await login(page, {
             user: argv.user || process.env.THREADS_USER || "ol.matsuk",
         });
 


### PR DESCRIPTION
## Summary
- rename `ensureThreadsReady` to `login` and adjust default export
- update action and runner modules to import and invoke `login`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b070a3c083328ddf6c34590dc51a