### PR TITLE
chore: verify Threads feed before actions

### DIFF
--- a/actions/feed.engage.js
+++ b/actions/feed.engage.js
@@ -1,6 +1,6 @@
 // actions/feed.engage.js
 import { ensureThreadsReady } from '../core/login.js';
-import { scrollAndReact } from '../core/feed.js';
+import { isOnThreadsFeed, scrollAndReact } from '../core/feed.js';
 import { BUSINESS_SEARCH_KEYWORDS } from '../coach_prompts/prompts.js';
 
 /**
@@ -18,6 +18,9 @@ export async function run(page, {
     IG_USER = 'ol.matsuk',
 } = {}) {
     await ensureThreadsReady(page, timeout, { IG_USER });
+    if (!(await isOnThreadsFeed(page, IG_USER))) {
+        throw new Error('Not on Threads feed');
+    }
     const res = await scrollAndReact(page, { rounds, pause, keywords, doLike, doComment, commentText });
     return { ok: true, ...res };
 }

--- a/actions/post.write.js
+++ b/actions/post.write.js
@@ -1,5 +1,6 @@
 // actions/post.write.js
 import { ensureThreadsReady } from '../core/login.js';
+import { isOnThreadsFeed } from '../core/feed.js';
 import { openComposer, fillAndPost } from '../core/composer.js';
 import { buildPromptForType, MAX_CHARS } from '../coach_prompts/prompts.js';
 
@@ -22,6 +23,9 @@ export async function run(page, {
 } = {}) {
     // 1) гарантуємо Threads
     await ensureThreadsReady(page, timeout, { IG_USER });
+    if (!(await isOnThreadsFeed(page, IG_USER))) {
+        throw new Error('Not on Threads feed');
+    }
 
     // 2) відкриваємо композер
     await openComposer(page, timeout);

--- a/actions/search.follow.js
+++ b/actions/search.follow.js
@@ -1,5 +1,6 @@
 // actions/search.follow.js
 import { ensureThreadsReady } from '../core/login.js';
+import { isOnThreadsFeed } from '../core/feed.js';
 import { waitForAny, clickAny } from '../utils.js';
 
 /**
@@ -20,6 +21,9 @@ export async function run(page, {
     IG_USER = 'ol.matsuk'
 } = {}) {
     await ensureThreadsReady(page, timeout, { IG_USER });
+    if (!(await isOnThreadsFeed(page, IG_USER))) {
+        throw new Error('Not on Threads feed');
+    }
 
     // Відкриваємо пошук
     await clickAny(page, [

--- a/core/feed.js
+++ b/core/feed.js
@@ -1,5 +1,19 @@
 // core/feed.js
 import { waitForAny, screenshotStep } from '../utils.js';
+import { THREADS_PROFILE_LINK, THREADS_COMPOSER_ANY } from '../constants/selectors.js';
+
+export async function isOnThreadsFeed(page, expectedUser) {
+    return await page
+        .evaluate(({ PROFILE, COMPOSER, expectedUser }) => {
+            const hasComposer = Array.from(document.querySelectorAll(COMPOSER))
+                .some(el => /Що нового\?|What’s new\?|What's new\?/i.test(el.textContent || ''));
+            const profile = document.querySelector(PROFILE);
+            const href = profile?.getAttribute('href') || '';
+            const userOk = expectedUser ? href.includes(`/${expectedUser}`) : true;
+            return hasComposer && userOk;
+        }, { PROFILE: THREADS_PROFILE_LINK, COMPOSER: THREADS_COMPOSER_ANY, expectedUser })
+        .catch(() => false);
+}
 
 export function matchesKeywords(text, keywords = []) {
     const t = (text || '').toLowerCase();


### PR DESCRIPTION
## Summary
- add `isOnThreadsFeed` helper for Threads feed checks
- require Threads feed presence before running actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b063cb30833293d91f756505c887