### PR TITLE
feat: expand login button selectors

### DIFF
--- a/test/loginButton.test.js
+++ b/test/loginButton.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import puppeteer from 'puppeteer';
+
+const htmlButton = `
+<div role="button" id="sso">
+  <div><span>Продовжити з Instagram</span></div>
+</div>
+`;
+
+test('clickContinueWithInstagramOnLogin handles standard button', async () => {
+  const { clickContinueWithInstagramOnLogin } = await import('../core/login.js');
+  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+  await page.setContent(htmlButton);
+  await assert.doesNotReject(() => clickContinueWithInstagramOnLogin(page));
+  await browser.close();
+});
+
+test('clickContinueWithInstagramOnLogin handles SVG icon button', async () => {
+  const { clickContinueWithInstagramOnLogin } = await import('../core/login.js');
+  const html = `
+    <div role="button" id="sso"><svg aria-label="Instagram"></svg></div>
+  `;
+  const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+  await page.setContent(html);
+  await assert.doesNotReject(() => clickContinueWithInstagramOnLogin(page));
+  await browser.close();
+});


### PR DESCRIPTION
## Summary
- broaden login button detection with a sequence of XPath and CSS fallbacks
- list attempted selectors for coach diagnostics when button is missing
- add Puppeteer tests covering standard and SVG-based buttons

## Testing
- `node --test test/loginButton.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5a5584ff48332af083862d8c9904e