### PR TITLE
feat: add Threads engagement actions

### DIFF
--- a/actions/engageByKeywords.js
+++ b/actions/engageByKeywords.js
@@ -1,0 +1,75 @@
+// actions/engageByKeywords.js
+import { isOnThreadsFeed } from '../core/feed.js';
+import * as coachAgent from '../coach/coachAgent.js';
+import { searchUsers } from './searchUsers.js';
+import { followUser } from './followUser.js';
+import { likeRandomPosts } from './likeRandomPosts.js';
+import { leaveComment } from './leaveComment.js';
+
+const pause = (min=200, max=600) => new Promise(r => setTimeout(r, Math.floor(min + Math.random()*(max-min))));
+const sample = (arr, n) => arr.sort(() => 0.5 - Math.random()).slice(0, n);
+
+export async function engageByKeywords(page, {
+  user,
+  keywords = ['підприємець','керівник','власник','бізнесмен','owner'],
+  maxProfilesPerRun = 4,
+  likePerProfile = 3,
+  commentChance = 0.35,
+  commentTemplates = [
+    'Дуже слушна думка!',
+    'Корисний досвід, дякую 🙌',
+    'Погоджуюсь. Так і має бути.',
+    'Цікава перспектива, беру на замітку.'
+  ]
+}) {
+  const ts = new Date().toISOString();
+  try {
+    if (!await isOnThreadsFeed(page, user)) {
+      throw new Error('Not on Threads feed or not authorized');
+    }
+
+    // 1) Обрати випадковий ключ
+    const keyword = keywords[Math.floor(Math.random()*keywords.length)];
+
+    // 2) Знайти профілі
+    const profiles = await searchUsers(page, { keyword, user });
+    const subset = sample(profiles, Math.min(maxProfilesPerRun, 4)); // 3–4 профілі
+
+    // 3) Пройтись по кожному профілю: лайки → підписка → (інколи) комент
+    const results = [];
+    for (const p of subset) {
+      const handle = p.handle.startsWith('/') ? p.handle : `/${p.handle}`;
+      const url = `https://www.threads.com${handle}`;
+      try {
+        await likeRandomPosts(page, { handleOrUrl: url, user, maxLikes: likePerProfile });
+        await pause();
+
+        const followRes = await followUser(page, { handleOrUrl: url, user });
+        await pause();
+
+        if (Math.random() < commentChance) {
+          await leaveComment(page, { handleOrUrl: url, user, templates: commentTemplates });
+          await pause();
+        }
+
+        results.push({ handle, followed: !followRes.alreadyFollowing });
+      } catch (e) {
+        await coachAgent.report({ stage: 'engageByKeywords:item', message: e.message, screenshotPath: null, context: { ts, handle } });
+      }
+    }
+
+    // Гарантовано повернутися у стрічку
+    try {
+      await page.evaluate(() => {
+        const home = document.querySelector('a[href="/"]');
+        if (home) home.click();
+      });
+      await pause(400,900);
+    } catch {}
+
+    return { ok: true, keyword, results };
+  } catch (err) {
+    await coachAgent.report({ stage: 'engageByKeywords', message: err.message, screenshotPath: null, context: { ts } });
+    throw err;
+  }
+}

--- a/actions/followUser.js
+++ b/actions/followUser.js
@@ -1,0 +1,50 @@
+// actions/followUser.js
+import { isOnThreadsFeed } from '../core/feed.js';
+import * as coachAgent from '../coach/coachAgent.js';
+import { SELECTORS } from '../constants/selectors.js';
+
+const pause = (min=200, max=600) => new Promise(r => setTimeout(r, Math.floor(min + Math.random()*(max-min))));
+const withRetry = async (name, fn, tries=3) => {
+  let lastErr;
+  for (let i=1;i<=tries;i++){
+    try { return await fn(); } catch (e){ lastErr=e; await pause(400,1000); }
+  }
+  throw Object.assign(new Error(`[${name}] failed after ${tries} retries`), { cause: lastErr });
+};
+
+export async function followUser(page, { handleOrUrl, user }) {
+  const ts = new Date().toISOString();
+  const profileUrl = handleOrUrl.startsWith('http') ? handleOrUrl : `https://www.threads.com/${handleOrUrl.replace(/^\/?/, '')}`;
+  try {
+    if (!await isOnThreadsFeed(page, user)) {
+      throw new Error('Not on Threads feed or not authorized');
+    }
+
+    // Відкрити профіль
+    await withRetry('gotoProfile', async () => {
+      await page.goto(profileUrl, { waitUntil: 'networkidle0', timeout: 30000 });
+      await pause(400,900);
+    });
+
+    // Якщо вже підписані — пропускаємо
+    const alreadyFollowing = await page.$(SELECTORS.profile.followingButton) !== null;
+    if (!alreadyFollowing) {
+      await withRetry('clickFollow', async () => {
+        await page.waitForSelector(SELECTORS.profile.followButton, { timeout: 10000 });
+        await page.click(SELECTORS.profile.followButton);
+        await pause(400,900);
+      });
+    }
+
+    // Повернутися у стрічку
+    await withRetry('backToFeed', async () => {
+      await page.click(SELECTORS.nav.home);
+      await pause(400,900);
+    });
+
+    return { ok: true, alreadyFollowing };
+  } catch (err) {
+    await coachAgent.report({ stage: 'followUser', message: err.message, screenshotPath: null, context: { handleOrUrl, ts } });
+    throw err;
+  }
+}

--- a/actions/leaveComment.js
+++ b/actions/leaveComment.js
@@ -1,0 +1,63 @@
+// actions/leaveComment.js
+import { isOnThreadsFeed } from '../core/feed.js';
+import * as coachAgent from '../coach/coachAgent.js';
+import { SELECTORS } from '../constants/selectors.js';
+
+const pause = (min=200, max=600) => new Promise(r => setTimeout(r, Math.floor(min + Math.random()*(max-min))));
+const withRetry = async (name, fn, tries=3) => {
+  let lastErr;
+  for (let i=1;i<=tries;i++){
+    try { return await fn(); } catch (e){ lastErr=e; await pause(400,1000); }
+  }
+  throw Object.assign(new Error(`[${name}] failed after ${tries} retries`), { cause: lastErr });
+};
+const pick = arr => arr[Math.floor(Math.random()*arr.length)];
+
+export async function leaveComment(page, { handleOrUrl, user, templates }) {
+  const ts = new Date().toISOString();
+  const profileUrl = handleOrUrl.startsWith('http') ? handleOrUrl : `https://www.threads.com/${handleOrUrl.replace(/^\/?/, '')}`;
+  const text = pick(templates);
+  try {
+    if (!await isOnThreadsFeed(page, user)) {
+      throw new Error('Not on Threads feed or not authorized');
+    }
+
+    // Відкрити профіль
+    await withRetry('gotoProfile', async () => {
+      await page.goto(profileUrl, { waitUntil: 'networkidle0', timeout: 30000 });
+      await pause(400,900);
+    });
+
+    // Відкрити останній/перший пост (або коментар інпут із карточки)
+    await withRetry('openFirstPost', async () => {
+      await page.waitForSelector(SELECTORS.profile.posts.firstPost, { timeout: 15000 });
+      await page.click(SELECTORS.profile.posts.firstPost);
+      await pause(400,900);
+    });
+
+    // Ввести коментар
+    await withRetry('typeComment', async () => {
+      await page.waitForSelector(SELECTORS.post.comment.input, { timeout: 10000 });
+      await page.click(SELECTORS.post.comment.input);
+      await page.type(SELECTORS.post.comment.input, text, { delay: 40 + Math.floor(Math.random()*40) });
+      await pause();
+      await page.click(SELECTORS.post.comment.submit);
+      await pause(500,1000);
+    });
+
+    // Закрити пост (якщо модалка) і назад у стрічку
+    await withRetry('closeAndBack', async () => {
+      if (await page.$(SELECTORS.post.closeModal)) {
+        await page.click(SELECTORS.post.closeModal);
+        await pause(200,600);
+      }
+      await page.click(SELECTORS.nav.home);
+      await pause(400,900);
+    });
+
+    return { ok: true, comment: text };
+  } catch (err) {
+    await coachAgent.report({ stage: 'leaveComment', message: err.message, screenshotPath: null, context: { handleOrUrl, ts, text } });
+    throw err;
+  }
+}

--- a/actions/likeRandomPosts.js
+++ b/actions/likeRandomPosts.js
@@ -1,0 +1,56 @@
+// actions/likeRandomPosts.js
+import { isOnThreadsFeed } from '../core/feed.js';
+import * as coachAgent from '../coach/coachAgent.js';
+import { SELECTORS } from '../constants/selectors.js';
+
+const pause = (min=200, max=600) => new Promise(r => setTimeout(r, Math.floor(min + Math.random()*(max-min))));
+const withRetry = async (name, fn, tries=3) => {
+  let lastErr;
+  for (let i=1;i<=tries;i++){
+    try { return await fn(); } catch (e){ lastErr=e; await pause(400,1000); }
+  }
+  throw Object.assign(new Error(`[${name}] failed after ${tries} retries`), { cause: lastErr });
+};
+const sample = (arr, n) => arr.sort(() => 0.5 - Math.random()).slice(0, n);
+
+export async function likeRandomPosts(page, { handleOrUrl, user, maxLikes = 4 }) {
+  const ts = new Date().toISOString();
+  const profileUrl = handleOrUrl.startsWith('http') ? handleOrUrl : `https://www.threads.com/${handleOrUrl.replace(/^\/?/, '')}`;
+  try {
+    if (!await isOnThreadsFeed(page, user)) {
+      throw new Error('Not on Threads feed or not authorized');
+    }
+
+    // Відкрити профіль
+    await withRetry('gotoProfile', async () => {
+      await page.goto(profileUrl, { waitUntil: 'networkidle0', timeout: 30000 });
+      await pause(400,900);
+    });
+
+    // Зібрати кнопки «лайк» на стрічці профілю
+    const likeSelectors = SELECTORS.profile.posts.likeButtons;
+    const postLikeHandles = await withRetry('collectLikeButtons', async () => {
+      await page.waitForSelector(likeSelectors.root, { timeout: 15000 });
+      return await page.$$(likeSelectors.item);
+    });
+
+    const toLike = sample(postLikeHandles, Math.min(maxLikes, 4)); // ліміт 3–4
+    for (const btn of toLike) {
+      try {
+        await btn.click();
+        await pause();
+      } catch {}
+    }
+
+    // Повернутися у стрічку
+    await withRetry('backToFeed', async () => {
+      await page.click(SELECTORS.nav.home);
+      await pause(400,900);
+    });
+
+    return { ok: true, liked: toLike.length };
+  } catch (err) {
+    await coachAgent.report({ stage: 'likeRandomPosts', message: err.message, screenshotPath: null, context: { handleOrUrl, ts } });
+    throw err;
+  }
+}

--- a/actions/searchUsers.js
+++ b/actions/searchUsers.js
@@ -1,0 +1,58 @@
+// actions/searchUsers.js
+import { isOnThreadsFeed } from '../core/feed.js';
+import * as coachAgent from '../coach/coachAgent.js';
+import { SELECTORS } from '../constants/selectors.js';
+
+const pause = (min=200, max=600) => new Promise(r => setTimeout(r, Math.floor(min + Math.random()*(max-min))));
+const withRetry = async (name, fn, tries=3) => {
+  let lastErr;
+  for (let i=1;i<=tries;i++){
+    try { return await fn(); } catch (e){ lastErr=e; await pause(400,1000); }
+  }
+  throw Object.assign(new Error(`[${name}] failed after ${tries} retries`), { cause: lastErr });
+};
+
+export async function searchUsers(page, { keyword, user }) {
+  const ts = new Date().toISOString();
+  try {
+    if (!await isOnThreadsFeed(page, user)) {
+      throw new Error('Not on Threads feed or not authorized');
+    }
+
+    // Відкрити пошук (іконка «лупа» у верхньому/нижньому барі)
+    await withRetry('openSearch', async () => {
+      await page.waitForSelector(SELECTORS.feed.searchButton, { timeout: 10000 });
+      await page.click(SELECTORS.feed.searchButton);
+      await pause();
+    });
+
+    // Ввести ключове слово
+    await withRetry('typeKeyword', async () => {
+      await page.waitForSelector(SELECTORS.search.input, { timeout: 10000 });
+      await page.click(SELECTORS.search.input, { clickCount: 3 });
+      await page.type(SELECTORS.search.input, keyword, { delay: 50 + Math.floor(Math.random()*60) });
+      await pause(500,900);
+    });
+
+    // Зібрати перші результати-профілі
+    const profiles = await withRetry('collectProfiles', async () => {
+      await page.waitForSelector(SELECTORS.search.results.profileCards, { timeout: 15000 });
+      return await page.$$eval(SELECTORS.search.results.profileCards, cards => cards.slice(0,20).map(c => {
+        const handle = c.querySelector('a[href^="/@"]')?.getAttribute('href') ?? null;
+        const title  = c.querySelector('a[href^="/@"]')?.textContent?.trim() ?? null;
+        return { handle, title };
+      }).filter(x => x.handle));
+    });
+
+    // Повернутися в стрічку
+    await withRetry('backToFeed', async () => {
+      await page.click(SELECTORS.nav.backOrHome); // кнопка «Назад» або «Додому»
+      await pause(300,800);
+    });
+
+    return profiles;
+  } catch (err) {
+    await coachAgent.report({ stage: 'searchUsers', message: err.message, screenshotPath: null, context: { keyword, ts } });
+    throw err;
+  }
+}

--- a/constants/selectors.js
+++ b/constants/selectors.js
@@ -31,3 +31,38 @@ export const IG_SUBMIT_BTN = 'button[type="submit"]';
 // Шляхи для cookies
 export const COOKIES_THREADS_PATH = "cookies.json";
 export const COOKIES_IG_PATH = "cookies_instagram.json";
+
+// Узагальнені селектори для дій у Threads
+export const SELECTORS = {
+  nav: {
+    home: 'a[href="/"]',
+    backOrHome: 'a[href="/"], button[aria-label="Back"], div[role="button"][aria-label="Back"]'
+  },
+  feed: {
+    searchButton: 'a[href="/search"], button[aria-label="Search"], [aria-label="Search"]'
+  },
+  search: {
+    input: 'input[type="search"], input[role="searchbox"], input[placeholder]',
+    results: {
+      profileCards: 'div[role="dialog"] a[href^="/@"], div[role="listitem"] a[href^="/@"], div a[href^="/@"]'
+    }
+  },
+  profile: {
+    followButton: 'button:has(span:matches-css(^Підписатися$)), button:has(span:matches-css(^Follow$))',
+    followingButton: 'button:has(span:matches-css(^Ви підписані$)), button:has(span:matches-css(^Following$))',
+    posts: {
+      likeButtons: {
+        root: 'main, div[role="main"]',
+        item: 'button[aria-label="Like"], div[role="button"][aria-label="Like"], div[aria-label="Like"]'
+      },
+      firstPost: 'article, div[role="article"], div[data-testid="post"]'
+    }
+  },
+  post: {
+    comment: {
+      input: 'textarea, [contenteditable="true"]',
+      submit: 'button[type="submit"], button[aria-label="Post"], div[role="button"][aria-label="Post"]'
+    },
+    closeModal: 'button[aria-label="Close"], [data-testid="sheet-close"], div[role="button"][aria-label="Close"]'
+  }
+};


### PR DESCRIPTION
## Summary
- add generalized DOM selectors for feed, profile, search and post interactions
- implement actions to search users, follow profiles, like random posts and leave comments
- compose engageByKeywords orchestrator combining search, follow, like and comment steps

## Testing
- `npm test` *(fails: 2, pass: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b6be1ae08332b240c24c6a153953