### PR TITLE
Log button selectors and page URLs

### DIFF
--- a/core/browser.js
+++ b/core/browser.js
@@ -28,6 +28,25 @@ export async function launchBrowser({ headless = false } = {}) {
 export async function newPageWithCookies(browser) {
     const page = await browser.newPage();
     await loadCookies(page, 'cookies_instagram.json').catch(() => { });
+    // Wrap native page.click to log selector and current URL
+    const origClick = page.click.bind(page);
+    page.click = async (selector, options) => {
+        try {
+            logStep(`CLICK ${selector} @ ${page.url()}`);
+        } catch { /* ignore logging errors */ }
+        return origClick(selector, options);
+    };
+
+    // Also log navigations via page.goto
+    const origGoto = page.goto.bind(page);
+    page.goto = async (...args) => {
+        const res = await origGoto(...args);
+        try {
+            logStep(`GOTO ${page.url()}`);
+        } catch { /* ignore logging errors */ }
+        return res;
+    };
+
     return page;
 }
 

--- a/utils.js
+++ b/utils.js
@@ -87,6 +87,9 @@ export async function waitForAny(page, selectors, { timeout = 10000, visible = t
 
 /** Клік по ПЕРШОМУ доступному селектору зі списку */
 export async function clickAny(page, selectors, { timeout = 8000, purpose = '' } = {}) {
+    try {
+        logStep(`CLICK_ANY ${selectors.join(', ')} @ ${page.url()}`);
+    } catch { /* ignore logging errors */ }
     const h = await waitForAny(page, selectors, { timeout, optional: true, visible: true, purpose });
     if (!h) return false;
     await h.click().catch(() => { });
@@ -102,6 +105,10 @@ export async function clickAny(page, selectors, { timeout = 8000, purpose = '' }
 export async function clickByText(page, a, b, { timeout = 8000 } = {}) {
     const tags = (b === undefined) ? 'button,[role="button"],a,div,span' : a;
     const text = (b === undefined) ? a : b;
+
+    try {
+        logStep(`CLICK_BY_TEXT ${text} @ ${page.url()}`);
+    } catch { /* ignore logging errors */ }
 
     const ok = await page.evaluate(({ tags, text }) => {
         const take = (s) => (s || '').replace(/\s+/g, ' ').trim();
@@ -125,6 +132,10 @@ export async function clickByText(page, a, b, { timeout = 8000 } = {}) {
 export async function clickByPartialText(page, a, b, { timeout = 8000 } = {}) {
     const tags = (b === undefined) ? 'button,[role="button"],a,div,span' : a;
     const partial = (b === undefined) ? a : b;
+
+    try {
+        logStep(`CLICK_BY_PARTIAL ${partial} @ ${page.url()}`);
+    } catch { /* ignore logging errors */ }
 
     const ok = await page.evaluate(({ tags, partial }) => {
         const norm = (s) => (s || '').toLowerCase().replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## Summary
- log clicked selectors and navigation URLs by wrapping `page.click` and `page.goto`
- record page URL for click helpers `clickAny`, `clickByText`, and `clickByPartialText`

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bc0a89688332bf2ade4ecb1e6797