### PR TITLE
feat: deepen selector search

### DIFF
--- a/test/waitForAny.test.js
+++ b/test/waitForAny.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'assert/strict';
+import { waitForAny } from '../utils.js';
+
+// Переконуємось, що кожен селектор справді використано у пошуку
+// ітерації відбуваються навіть при відсутності результату
+
+test('waitForAny attempts all selectors', async () => {
+  const attempted = [];
+  const fakeHandle = { asElement: () => null, dispose: async () => {} };
+  const page = {
+    frames: () => [],
+    evaluateHandle: async (fn, sel) => { attempted.push(sel); return fakeHandle; }
+  };
+  const selectors = ['.one', '.two', '.three'];
+  await waitForAny(page, selectors, { timeout: 30, optional: true });
+  assert.deepEqual(new Set(attempted), new Set(selectors));
+});


### PR DESCRIPTION
## Summary
- extend waitForAny to deduplicate selectors and traverse shadow DOM and frames
- add unit test to ensure all selectors are attempted

## Testing
- `npm test` *(fails: Failed to launch the browser process! error while loading shared libraries: libXrandr.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d05393b88332b4f3971474cac6e3