### PR TITLE
Improve Threads login detection

### DIFF
--- a/constants/selectors.js
+++ b/constants/selectors.js
@@ -10,7 +10,10 @@ export const THREADS_HOME_URLS = [
 // На головній (неавторизовано)
 // 1) canonical <a href="/login">
 // 2) будь-який видимий елемент з role="button", що виглядає як SSO Instagram
-export const THREADS_LOGIN_ANCHOR = 'a[href="/login"]';
+export const THREADS_LOGIN_ANCHOR = 'a[href^="/login"]';
+
+// Текст посилання/кнопки входу
+export const THREADS_LOGIN_ENTRY_TEXT = /Увійти|Log in/i;
 
 // На сторінці /login — SSO-посилання/кнопка
 export const THREADS_CONTINUE_WITH_IG = 'a[href*="instagram.com"], a[href="/login"], button[data-testid="login"]';

--- a/core/login.js
+++ b/core/login.js
@@ -12,6 +12,7 @@ import { getIgCreds } from "./auth.js";
 import {
     THREADS_HOME_URLS,
     THREADS_LOGIN_ANCHOR,
+    THREADS_LOGIN_ENTRY_TEXT,
     THREADS_LOGIN_BUTTON_TEXT,
     THREADS_CONTINUE_WITH_IG,
     THREADS_PROFILE_LINK,
@@ -109,7 +110,7 @@ async function clickLoginEntryOnHome(page) {
     let handle = await page.$(THREADS_LOGIN_ANCHOR);
 
     if (!handle) {
-        logStep(`На сторінці ${url}: не знайдено ${THREADS_LOGIN_ANCHOR}, шукаю role="button" з текстом /${THREADS_LOGIN_BUTTON_TEXT.source}/`);
+        logStep(`На сторінці ${url}: не знайдено ${THREADS_LOGIN_ANCHOR}, шукаю role="button" з текстом /${THREADS_LOGIN_ENTRY_TEXT.source}/`);
         handle = await page.evaluateHandle((reSource) => {
             const re = new RegExp(reSource, "i");
             const nodes = Array.from(document.querySelectorAll('[role="button"],button,a,div,span'));
@@ -119,7 +120,7 @@ async function clickLoginEntryOnHome(page) {
                 return r.width > 4 && r.height > 4 && cs.visibility !== "hidden" && cs.display !== "none";
             };
             return nodes.find(n => n.textContent && re.test(n.textContent) && isVisible(n)) || null;
-        }, THREADS_LOGIN_BUTTON_TEXT.source).catch(() => null);
+        }, THREADS_LOGIN_ENTRY_TEXT.source).catch(() => null);
     }
 
     if (!handle) {
@@ -127,7 +128,7 @@ async function clickLoginEntryOnHome(page) {
         fs.writeFileSync(path.resolve("коди сторінок", "threads_home_missing_login.html"), dom);
         const shot = await takeShot(page, "coach_login_entry");
         const goal = "Find and click login/SSO button on Threads home to navigate to /login";
-        const candidates = { tried: [THREADS_LOGIN_ANCHOR, `role=button + /${THREADS_LOGIN_BUTTON_TEXT.source}/`] };
+        const candidates = { tried: [THREADS_LOGIN_ANCHOR, `role=button + /${THREADS_LOGIN_ENTRY_TEXT.source}/`] };
         const coach = await consultAndExecute({
             page, stage: "threads.loginEntry", message: "Login entry not found",
             goal, screenshotPath: shot, dom, candidates


### PR DESCRIPTION
## Summary
- broaden `THREADS_LOGIN_ANCHOR` to match any `/login` path
- add `THREADS_LOGIN_ENTRY_TEXT` for "Log in/Увійти" button text
- use new login entry text when searching home page

## Testing
- `npm test` *(fails: btn is not defined)*
- `node …` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED at https://www.threads.com/?hl=uk)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d6e93e308332b04529ee2a040566