### PR TITLE
Open Puppeteer browser maximized instead of fullscreen

### DIFF
--- a/core/browser.js
+++ b/core/browser.js
@@ -14,7 +14,7 @@ puppeteer.use(StealthPlugin());
 export async function launchBrowser({ headless = false } = {}) {
     const browser = await puppeteer.launch({
         headless,
-        args: ['--no-sandbox', '--disable-setuid-sandbox', '--lang=uk-UA', '--start-fullscreen'],
+        args: ['--no-sandbox', '--disable-setuid-sandbox', '--lang=uk-UA', '--start-maximized'],
         defaultViewport: null
     });
     return browser;


### PR DESCRIPTION
## Summary
- launch browser with `--start-maximized` so address bar and icons remain visible

## Testing
- `npm test` *(fails: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d89a027883328891b1f87d1cb422