### PR TITLE
Add Threads login form credential support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ IG_USER / INSTAGRAM_USER
 
 IG_PASS / INSTAGRAM_PASS
 
+THREADS_USERNAME
+
+THREADS_PASSWORD
+
 OPENAI_API_KEY (+ опційно OPENAI_MODEL, за замовчуванням gpt-4o-mini)
 
 (ми вже передаємо --no-sandbox у Chromium флагах)

--- a/constants/selectors.js
+++ b/constants/selectors.js
@@ -26,7 +26,7 @@ export const THREADS_LOGIN_BUTTON_TEXT = /Продовжити з Instagram|Cont
 // Форма логіну Threads (fallback, якщо нема SSO)
 export const THREADS_LOGIN_USER_INPUT = 'input[type="text"], input[type="email"], input[name="username"], input[autocomplete="username"]';
 export const THREADS_LOGIN_PASS_INPUT = 'input[type="password"], input[name="password"], input[autocomplete="current-password"]';
-export const THREADS_LOGIN_SUBMIT = 'button[type="submit"], button';
+export const THREADS_LOGIN_SUBMIT = 'button[type="submit"], input[type="submit"], button';
 
 // Ознаки авторизованого фіду
 export const THREADS_PROFILE_LINK = 'a[href^="/@"]';

--- a/core/auth.js
+++ b/core/auth.js
@@ -5,3 +5,10 @@ export function getIgCreds() {
     if (!user || !pass) throw new Error("[FATAL] IG_USER / IG_PASS відсутні у .env");
     return { user, pass };
 }
+
+export function getThreadsCreds() {
+    const user = (process.env.THREADS_USERNAME || "").trim();
+    const pass = (process.env.THREADS_PASSWORD || "").trim();
+    if (!user || !pass) throw new Error("[FATAL] THREADS_USERNAME / THREADS_PASSWORD відсутні у .env");
+    return { user, pass };
+}

--- a/core/login.js
+++ b/core/login.js
@@ -8,7 +8,7 @@ import {
 } from "../helpers/logger.js";
 import { consultAndExecute } from "../coach/coachAgent.js";
 import { tryStep } from "../helpers/misc.js";
-import { getIgCreds } from "./auth.js";
+import { getIgCreds, getThreadsCreds } from "./auth.js";
 import {
     THREADS_HOME_URLS,
     THREADS_LOGIN_ANCHOR,
@@ -431,8 +431,8 @@ export async function handleSaveCredentialsIfAppears(page) {
 }
 
 export async function ensureThreadsReady(page, opts = {}) {
-    const { user: igUser, pass } = getIgCreds();
-    const wantedUser = opts.user || igUser || process.env.THREADS_USER || "ol.matsuk";
+    const { user: igUser, pass: igPass } = getIgCreds();
+    const { user: threadsUser, pass: threadsPass } = getThreadsCreds();
 
     page.setDefaultTimeout(20000);
     page.setDefaultNavigationTimeout(30000);
@@ -459,7 +459,7 @@ export async function ensureThreadsReady(page, opts = {}) {
 
     await tryStep("login entry on home", () => clickLoginEntryOnHome(page), { page });
 
-    await tryStep("threads login or sso", () => clickContinueWithInstagramOnLogin(page, { user: igUser, pass }), { page });
+    await tryStep("threads login or sso", () => clickContinueWithInstagramOnLogin(page, { user: threadsUser, pass: threadsPass }), { page });
 
     await tryStep("wait instagram redirect", () => waitUrlHas(page, "instagram.com", 25000), { page });
 
@@ -485,7 +485,7 @@ export async function ensureThreadsReady(page, opts = {}) {
         // (б) Форма логіну IG
         const hasForm = await page.$(IG_LOGIN_FORM);
         if (hasForm) {
-            if (!igUser || !pass) {
+            if (!igUser || !igPass) {
                 const e = new Error("IG_USER / IG_PASS не задані для логіну в Instagram.");
                 e.keepOpen = true;
                 throw e;
@@ -502,7 +502,7 @@ export async function ensureThreadsReady(page, opts = {}) {
             await page.keyboard.down("Control").catch(() => { });
             await page.keyboard.press("A").catch(() => { });
             await page.keyboard.up("Control").catch(() => { });
-            await page.type(IG_PASS_INPUT, pass, { delay: 20 });
+            await page.type(IG_PASS_INPUT, igPass, { delay: 20 });
 
             await takeShot(page, "ig_login_filled");
 


### PR DESCRIPTION
## Summary
- add helper to read THREADS_USERNAME and THREADS_PASSWORD from environment
- expand login submit selector to handle input submit elements
- use new Threads credentials when filling login form
- document new environment variables

## Testing
- `npm test` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dce8a65483329b49d1277e1783b9