### PR TITLE
Use Threads login page with Ukrainian locale

### DIFF
--- a/constants/selectors.js
+++ b/constants/selectors.js
@@ -2,7 +2,7 @@
 // Стабільні селектори без прив'язки до локалізації UI
 
 export const THREADS_HOME_URLS = [
-    "https://www.threads.com/?hl=uk",
+    "https://www.threads.com/login?hl=uk",
     "https://www.threads.net/?hl=uk",
     "https://threads.net/?hl=uk",
 ];

--- a/core/login.js
+++ b/core/login.js
@@ -394,7 +394,7 @@ export async function ensureThreadsReady(page, opts = {}) {
 
     await tryStep("Go to Threads login", async () => {
         await retry(async () => {
-            await page.goto('https://www.threads.com/login', { waitUntil: "domcontentloaded", timeout: 30000 });
+            await page.goto('https://www.threads.com/login?hl=uk', { waitUntil: "domcontentloaded", timeout: 30000 });
         });
         await takeShot(page, "login_loaded");
     }, { page });

--- a/core/threadsBridge.js
+++ b/core/threadsBridge.js
@@ -5,7 +5,7 @@ export async function continueWithInstagramOnThreads(page, timeout = 20000) {
     logStep('Перехід на threads.net');
     await page.goto('https://www.threads.net/', { waitUntil: 'domcontentloaded' }).catch(() => { });
     if (!(page.url().includes('threads.net') || page.url().includes('threads.com'))) {
-        await page.goto('https://www.threads.com/', { waitUntil: 'domcontentloaded' }).catch(() => { });
+        await page.goto('https://www.threads.com/login?hl=uk', { waitUntil: 'domcontentloaded' }).catch(() => { });
     }
 
     // Пошук та клік по "Continue with Instagram"

--- a/postThreads_old.js
+++ b/postThreads_old.js
@@ -176,7 +176,7 @@ async function continueWithInstagramOnThreads(page, timeout) {
     logStep('Перехід на threads.net');
     await page.goto('https://www.threads.net/', { waitUntil: 'domcontentloaded' }).catch(() => { });
     if (!(page.url().includes('threads.net') || page.url().includes('threads.com'))) {
-        await page.goto('https://www.threads.com/', { waitUntil: 'domcontentloaded' }).catch(() => { });
+        await page.goto('https://www.threads.com/login?hl=uk', { waitUntil: 'domcontentloaded' }).catch(() => { });
     }
 
     if (await isThreadsAuthed(page)) {


### PR DESCRIPTION
## Summary
- navigate to Threads login page with `hl=uk` instead of the root page
- update home URL list to point to login
- ensure login flow uses localized login page

## Testing
- `npm test` *(fails: Failed to launch the browser process - libXcomposite.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e481db4c8332a175993abc8454e6