### PR TITLE
Add delay and highlight before login form submission

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -454,8 +454,16 @@ export async function ensureThreadsReady(page, opts = {}) {
 
                 await takeShot(page, "ig_login_filled");
 
+                await page.evaluate((selector) => {
+                    const btn = document.querySelector(selector) ||
+                        Array.from(document.querySelectorAll('button,[role="button"]'))
+                            .find(b => /log in|увійти/i.test(b.textContent || ""));
+                    if (btn) btn.style.boxShadow = '0 0 4px 2px #4ea5ff';
+                }, IG_SUBMIT_BTN);
+                await page.waitForTimeout(500);
+
                 await Promise.all([
-                    page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 45000 }).catch(() => { }),
+                    page.waitForNavigation({ waitUntil: "networkidle0", timeout: 45000 }).catch(() => { }),
                     page.click(IG_SUBMIT_BTN).catch(async () => {
                         await page.evaluate(() => {
                             const btn = Array.from(document.querySelectorAll('button,[role="button"]'))


### PR DESCRIPTION
## Summary
- highlight Instagram login submit button and wait briefly before submission
- wait for network to be idle after submitting the form

## Testing
- `npm test` *(fails: Failed to launch the browser process: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e791eccc8332a690e7746308b028