### PR TITLE
Refactor post flow to use Threads login

### DIFF
--- a/postThreads.js
+++ b/postThreads.js
@@ -5,15 +5,14 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { launchBrowser, newPageWithCookies } from './core/browser.js';
-import { loginInstagram } from './core/auth.js';
-import { continueWithInstagramOnThreads } from './core/threadsBridge.js';
+import { ensureThreadsReady } from './core/login.js';
 import { openComposer } from './core/composer.js';
 
 import { run as runPost } from './actions/post.js';
 import { run as runFind } from './actions/findEntrepreneurs.js';
 import { run as runFeed, scrollPastSuggestionsIfPresent } from './actions/feedScan.js';
 
-import { logStep, saveCookies, loadCookies } from './utils.js';
+import { logStep } from './utils.js';
 
 const argv = yargs(hideBin(process.argv))
     .option('action', { type: 'string', default: 'post', choices: ['post', 'find-entrepreneurs', 'feed-scan', 'skip-suggestions'] })
@@ -25,13 +24,7 @@ const argv = yargs(hideBin(process.argv))
     .option('otp', { type: 'string' })
     .parse();
 
-const IG_USER = process.env.IG_USER || process.env.INSTAGRAM_USER;
-const IG_PASS = process.env.IG_PASS || process.env.INSTAGRAM_PASS;
 const HEADLESS = argv.headless ?? (process.env.HEADLESS === 'true');
-
-if (!IG_USER || !IG_PASS) {
-    console.error('[FATAL] IG_USER/IG_PASS не задані у .env'); process.exit(1);
-}
 
 (async () => {
     logStep('Старт бота постингу в Threads');
@@ -39,20 +32,10 @@ if (!IG_USER || !IG_PASS) {
     const page = await newPageWithCookies(browser);
 
     try {
-        // 0) спробувати підвантажити куки до будь-яких дій
-        await loadCookies(page, 'cookies_instagram.json').then(() => {
-            console.log('[COOKIES] застосовані cookies_instagram.json (якщо існували)');
-        }).catch(() => { });
+        // 1) Авторизація та підготовка Threads
+        await ensureThreadsReady(page);
 
-        // 1) Завжди виконуємо логін до Instagram
-        logStep('Перехід на instagram.com (логін)');
-        await loginInstagram(page, argv.timeout, { user: IG_USER, pass: IG_PASS, otp: argv.otp });
-        await saveCookies(page, 'cookies_instagram.json').catch(() => { });
-
-        // 2) Threads SSO + вибір акаунта
-        await continueWithInstagramOnThreads(page, argv.timeout, { IG_USER: IG_USER });
-
-        // 3) ДІЇ
+        // 2) ДІЇ
         if (argv.action === 'post') {
             const input = await openComposer(page, argv.timeout); // забезпечує відкриття попапа і фокус
             await runPost(page, { ...argv, composerHandle: input });
@@ -66,14 +49,10 @@ if (!IG_USER || !IG_PASS) {
             throw new Error(`Невідомий action: ${argv.action}`);
         }
 
-        // 4) зберігаємо cookies на виході
-        await saveCookies(page, 'cookies_instagram.json').catch(() => { });
-
     } catch (err) {
         console.error('[ERROR]', err?.stack || err?.message || err);
         try { const ts = new Date().toISOString().replace(/[:.]/g, '-'); await page.screenshot({ path: `error_${ts}.png`, fullPage: true }); } catch { }
     } finally {
         // браузер спеціально НЕ закриваємо, щоб залишити сесію відкритою
-        try { await saveCookies(page, 'cookies_instagram.json'); } catch { }
     }
 })();

--- a/runners/threads.js
+++ b/runners/threads.js
@@ -49,7 +49,7 @@ async function main() {
     await saveCookies(page, 'cookies_instagram.json').catch(() => { });
 
     try {
-        if (action !== "login.test") throw new Error(`Unknown --action=${action}`);
+        if (!["login.test", "login"].includes(action)) throw new Error(`Unknown --action=${action}`);
 
         logStep("Запуск дії login.test");
         await ensureThreadsReady(page, {


### PR DESCRIPTION
## Summary
- Use `ensureThreadsReady` for Threads authentication in post runner
- Allow `runners/threads.js` to accept `--action=login`

## Testing
- `node postThreads.js --action post --type humor` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*
- `node runners/threads.js --action login --headless false` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f5246b548332a46a2fac71ba7257