### PR TITLE
feat: add random action option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ npm i
 
 node postThreads.js --action=<дія> [опції]
 
+Щоб випадково виконати одну з доступних дій (окрім логіну), використай `--action=random`.
+
 1) Публікація треда
 node postThreads.js --action=post [--type=story|tip|news] [--text="готовий текст"] [--image="шлях/до/фото.png"] [--headless=true]
 

--- a/postThreads.js
+++ b/postThreads.js
@@ -15,7 +15,7 @@ import { run as runFeed, scrollPastSuggestionsIfPresent } from './actions/feedSc
 import { logStep } from './utils.js';
 
 const argv = yargs(hideBin(process.argv))
-    .option('action', { type: 'string', default: 'post', choices: ['post', 'find-entrepreneurs', 'feed-scan', 'skip-suggestions'] })
+    .option('action', { type: 'string', default: 'post', choices: ['post', 'find-entrepreneurs', 'feed-scan', 'skip-suggestions', 'random'] })
     .option('type', { type: 'string', choices: ['story', 'tip', 'news', 'humor'] })
     .option('text', { type: 'string' })
     .option('image', { type: 'string' })
@@ -36,17 +36,24 @@ const HEADLESS = argv.headless ?? (process.env.HEADLESS === 'true');
         await ensureThreadsReady(page);
 
         // 2) ДІЇ
-        if (argv.action === 'post') {
+        let action = argv.action;
+        if (action === 'random') {
+            const choices = ['post', 'find-entrepreneurs', 'feed-scan', 'skip-suggestions'];
+            action = choices[Math.floor(Math.random() * choices.length)];
+            logStep(`Випадково обрано дію: ${action}`);
+        }
+
+        if (action === 'post') {
             const input = await openComposer(page, argv.timeout); // забезпечує відкриття попапа і фокус
             await runPost(page, { ...argv, composerHandle: input });
-        } else if (argv.action === 'find-entrepreneurs') {
+        } else if (action === 'find-entrepreneurs') {
             await runFind(page, argv);
-        } else if (argv.action === 'feed-scan') {
+        } else if (action === 'feed-scan') {
             await runFeed(page, argv);
-        } else if (argv.action === 'skip-suggestions') {
+        } else if (action === 'skip-suggestions') {
             await scrollPastSuggestionsIfPresent(page);
         } else {
-            throw new Error(`Невідомий action: ${argv.action}`);
+            throw new Error(`Невідомий action: ${action}`);
         }
 
     } catch (err) {


### PR DESCRIPTION
## Summary
- allow `--action=random` to execute a randomly chosen bot action
- document random action in README

## Testing
- `node postThreads.js --action=random --headless=true` *(fails: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd317b008332ab3ceb18fb0e0a55