### PR TITLE
feat: implement feed scanning and entrepreneur search

### DIFF
--- a/actions/feedScan.js
+++ b/actions/feedScan.js
@@ -1,9 +1,47 @@
-export async function run() {
-  throw new Error('feedScan action is not implemented in this environment');
+// actions/feedScan.js
+// Сканування стрічки Threads із можливістю пропустити блок рекомендацій
+
+import { tryStep } from '../helpers/misc.js';
+import { ensureThreadsReady } from '../core/login.js';
+import { slowScroll } from '../utils.js';
+
+/**
+ * Прокручує стрічку декілька разів, попередньо авторизуючись.
+ * @param {import('puppeteer').Page} page
+ * @param {object} opts
+ * @param {number} [opts.scanScrolls=20] скільки кроків прокручування зробити
+ * @returns {Promise<object>} результат
+ */
+export async function run(page, { scanScrolls = 20 } = {}) {
+  await tryStep('ensureThreadsReady', () => ensureThreadsReady(page), { page });
+  await scrollPastSuggestionsIfPresent(page, { ensureLogin: false });
+  await slowScroll(page, scanScrolls);
+  return { ok: true };
 }
 
-export async function scrollPastSuggestionsIfPresent() {
-  return false;
+/**
+ * Якщо на початку стрічки є блок "Suggested for you", прокручує його, щоб
+ * стрічка містила лише пости з підписок.
+ * @param {import('puppeteer').Page} page
+ * @param {object} opts
+ * @param {boolean} [opts.ensureLogin=true] чи викликати логін усередині
+ * @returns {Promise<boolean>} true, якщо блок було знайдено й пропущено
+ */
+export async function scrollPastSuggestionsIfPresent(page, { ensureLogin = true } = {}) {
+  if (ensureLogin) {
+    await tryStep('ensureThreadsReady', () => ensureThreadsReady(page), { page });
+  }
+
+  const skipped = await page.evaluate(() => {
+    const headers = Array.from(document.querySelectorAll('h2, h3'));
+    const block = headers.find(h => /Suggested for you|Рекомендовано/i.test(h.textContent || ''));
+    if (!block) return false;
+    const rect = block.getBoundingClientRect();
+    window.scrollBy(0, rect.bottom + 50);
+    return true;
+  }).catch(() => false);
+
+  return skipped;
 }
 
 export default { run, scrollPastSuggestionsIfPresent };

--- a/actions/findEntrepreneurs.js
+++ b/actions/findEntrepreneurs.js
@@ -1,5 +1,39 @@
-export async function run() {
-  throw new Error('findEntrepreneurs action is not implemented in this environment');
+// actions/findEntrepreneurs.js
+// Виконує пошук профілів підприємців у Threads та підписується на кілька з них
+
+import { tryStep } from '../helpers/misc.js';
+import { ensureThreadsReady } from '../core/login.js';
+import { run as searchFollow } from './search.follow.js';
+
+/**
+ * Випадково шукає підприємців за ключовими словами та підписується на них.
+ * Початок: головна стрічка Threads
+ * Кінець: головна стрічка Threads
+ *
+ * @param {import('puppeteer').Page} page сторінка браузера
+ * @param {object} opts
+ * @param {number} [opts.maxFollows=3] максимальна кількість підписок
+ * @returns {Promise<object>} інформація про кількість підписок
+ */
+export async function run(page, { maxFollows = 3 } = {}) {
+  await tryStep('ensureThreadsReady', () => ensureThreadsReady(page), { page });
+
+  const keywords = [
+    'підприємець',
+    'керівник',
+    'власник',
+    'entrepreneur',
+    'owner',
+    'founder',
+  ];
+
+  const follows = Math.min(4, Math.max(0, maxFollows));
+
+  return await searchFollow(page, {
+    queries: keywords,
+    maxFollowsPerRun: follows,
+    likesPerProfile: [3, 4],
+  });
 }
 
 export default { run };


### PR DESCRIPTION
## Summary
- implement entrepreneur search action using `search.follow`
- add feed scanning action with optional suggestion skipping

## Testing
- `node postThreads.js --action=find-entrepreneurs --maxFollows=3` *(fails: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }))*
- `node postThreads.js --action=feed-scan --headless=true` *(fails: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }))*
- `node postThreads.js --action=skip-suggestions` *(fails: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ api Key: 'My API Key' }))*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5fa910f9083329bc14cd24b55638c