### PR TITLE
feat: enhance feed scan with AI comments

### DIFF
--- a/actions/feedScan.js
+++ b/actions/feedScan.js
@@ -3,19 +3,28 @@
 
 import { tryStep } from '../helpers/misc.js';
 import { ensureThreadsReady } from '../core/login.js';
-import { slowScroll } from '../utils.js';
+import { scrollAndReact } from '../core/feed.js';
+import { BUSINESS_SEARCH_KEYWORDS } from '../constants/keywords.js';
+import { getPositiveCommentForText } from '../contentProvider.js';
 
 /**
  * Прокручує стрічку декілька разів, попередньо авторизуючись.
  * @param {import('puppeteer').Page} page
  * @param {object} opts
- * @param {number} [opts.scanScrolls=20] скільки кроків прокручування зробити
+ * @param {number} [opts.scanScrolls=2] скільки кроків прокручування зробити
  * @returns {Promise<object>} результат
  */
-export async function run(page, { scanScrolls = 20 } = {}) {
+export async function run(page, { scanScrolls = 2 } = {}) {
   await tryStep('ensureThreadsReady', () => ensureThreadsReady(page), { page });
   await scrollPastSuggestionsIfPresent(page, { ensureLogin: false });
-  await slowScroll(page, scanScrolls);
+  await scrollAndReact(page, {
+    rounds: scanScrolls,
+    pause: 800,
+    keywords: BUSINESS_SEARCH_KEYWORDS,
+    doLike: true,
+    doComment: true,
+    generateComment: async (text) => await getPositiveCommentForText(text)
+  });
   return { ok: true };
 }
 

--- a/core/feed.js
+++ b/core/feed.js
@@ -26,7 +26,8 @@ export async function scrollAndReact(page, {
     keywords = [],
     doLike = true,
     doComment = false,
-    commentText = '🔥'
+    commentText = '🔥',
+    generateComment = null
 } = {}) {
     await waitForAny(page, ['body'], { timeout: 8000, optional: false });
     const reacted = { liked: 0, commented: 0 };
@@ -76,6 +77,7 @@ export async function scrollAndReact(page, {
             // комент
             if (doComment && p.comment) {
                 try {
+                    const reply = generateComment ? await generateComment(p.text) : commentText;
                     await page.evaluate((payload) => {
                         const { text, reply } = payload;
                         const blocks = document.querySelectorAll('article, div[role="article"], div.x78zum5.xdt5ytf');
@@ -87,12 +89,12 @@ export async function scrollAndReact(page, {
                                 break;
                             }
                         }
-                    }, { text: p.text, reply: commentText });
+                    }, { text: p.text, reply });
                     await page.waitForTimeout(300);
 
                     const replyBox = await page.$('textarea, div[contenteditable="true"]');
                     if (replyBox) {
-                        await replyBox.type(commentText, { delay: 10 });
+                        await replyBox.type(reply, { delay: 10 });
                         await page.keyboard.press('Enter');
                         reacted.commented++;
                         await page.waitForTimeout(300);


### PR DESCRIPTION
## Summary
- add OpenAI-powered comment generation for feed scanning
- allow feed scanning to react with likes and generated comments based on business keywords
- enable scrollAndReact to use dynamic per-post comments

## Testing
- `node postThreads.js --action=feed-scan --headless=true` (fails: The OPENAI_API_KEY environment variable is missing or empty)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b60860b6588332a76fe7d818245f6e