### PR TITLE
feat: retry login form when stay on login

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -151,6 +151,12 @@ export async function ensureThreadsReady(page, opts = {}) {
 
     await tryStep("threads login", () => fillThreadsLoginForm(page, threadsUser, threadsPass), { page });
 
+    if ((page.url() || "").includes("/login")) {
+        logStep("URL все ще /login, повторюю вхід");
+        await tryStep("threads login retry", () => fillThreadsLoginForm(page, threadsUser, threadsPass), { page });
+        await sleep(1000);
+    }
+
     await tryStep("Очікую завантаження фіду Threads…", () => waitUrlHas(page, "threads.", 45000), { page });
 
     const until = Date.now() + 70000;


### PR DESCRIPTION
## Summary
- retry Threads login if still on `/login` after first submit

## Testing
- `npm test`
- `node -e "fetch('https://example.com').then(r=>r.text()).then(t=>console.log('len',t.length)).catch(e=>console.error(e.message))"` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b613a7dbf48332b47b3f7302f2151c