### PR TITLE
Fix login submit selector

### DIFF
--- a/constants/selectors.js
+++ b/constants/selectors.js
@@ -18,7 +18,7 @@ export const THREADS_LOGIN_ENTRY_TEXT = /Увійти|Log in/i;
 // Форма логіну Threads
 export const THREADS_LOGIN_USER_INPUT = 'input[type="text"], input[type="email"], input[name="username"], input[autocomplete="username"]';
 export const THREADS_LOGIN_PASS_INPUT = 'input[type="password"], input[name="password"], input[autocomplete="current-password"]';
-export const THREADS_LOGIN_SUBMIT = 'button[type="submit"], input[type="submit"], button';
+export const THREADS_LOGIN_SUBMIT = 'form div[role="button"][tabindex="0"]:has(div:matches-css(^Увійти$|^Log in$))';
 
 // Ознаки авторизованого фіду
 export const THREADS_PROFILE_LINK = 'a[href^="/@"]';


### PR DESCRIPTION
## Summary
- refine Threads login submit selector to avoid volatile class names

## Testing
- `npm test`
- `node -e "import('node-fetch').then(({default:fetch})=>fetch('https://example.com').then(r=>r.status).then(s=>console.log('status',s)).catch(e=>console.error('fetch failed',e)))"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b619910a948332b81ec11f80027992