### PR TITLE
feat: use xpath login selector

### DIFF
--- a/constants/selectors.js
+++ b/constants/selectors.js
@@ -18,7 +18,7 @@ export const THREADS_LOGIN_ENTRY_TEXT = /Увійти|Log in/i;
 // Форма логіну Threads
 export const THREADS_LOGIN_USER_INPUT = 'input[type="text"], input[type="email"], input[name="username"], input[autocomplete="username"]';
 export const THREADS_LOGIN_PASS_INPUT = 'input[type="password"], input[name="password"], input[autocomplete="current-password"]';
-export const THREADS_LOGIN_SUBMIT = 'button[type="submit"], input[type="submit"], button';
+export const THREADS_LOGIN_SUBMIT = "(//button | //div[@role='button'] | //a[@role='button'])[ .//span[normalize-space()='Увійти'] or normalize-space()='Увійти' or contains(., 'Увійти') ]";
 
 // Ознаки авторизованого фіду
 export const THREADS_PROFILE_LINK = 'a[href^="/@"]';

--- a/core/login.js
+++ b/core/login.js
@@ -113,14 +113,19 @@ async function fillThreadsLoginForm(page, user, pass) {
 
     await Promise.all([
         page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 45000 }).catch(() => { }),
-        page.click(sSel).catch(async () => {
-            await page.evaluate((re) => {
-                const nodes = Array.from(document.querySelectorAll('button,[role="button"]'));
-                const rx = new RegExp(re, 'i');
-                const btn = nodes.find(n => rx.test(n.textContent || ''));
-                if (btn) btn.click();
-            }, THREADS_LOGIN_ENTRY_TEXT.source);
-        })
+        (async () => {
+            const [btn] = await page.$x(sSel).catch(() => []);
+            if (btn) {
+                await btn.click().catch(() => { });
+            } else {
+                await page.evaluate((re) => {
+                    const nodes = Array.from(document.querySelectorAll('button,[role="button"]'));
+                    const rx = new RegExp(re, 'i');
+                    const el = nodes.find(n => rx.test(n.textContent || ''));
+                    if (el) el.click();
+                }, THREADS_LOGIN_ENTRY_TEXT.source);
+            }
+        })()
     ]);
 
     await takeShot(page, 'threads_login_submit');


### PR DESCRIPTION
## Summary
- switch Threads login submission to an XPath selector targeting "Увійти" text
- adjust login helper to click buttons found via XPath for reliable auth

## Testing
- `npm test`
- `node -e "import('node-fetch').then(({default:fetch})=>fetch('https://example.com').then(r=>console.log('status',r.status)).catch(e=>console.error('fetch failed',e)))"` (fails: ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68b619910a948332b81ec11f80027992