### PR TITLE
refactor: replace deprecated waitForTimeout

### DIFF
--- a/DOCS/MAINTAINERS_GUIDE.md
+++ b/DOCS/MAINTAINERS_GUIDE.md
@@ -30,7 +30,7 @@
 ## Код-стайл
 - Імена функцій — дієслово в camelCase.
 - У діях (`actions/*`) імперативний тон логів: `[STEP] ...`.
-- Максимум відкладених `await page.waitForTimeout(…)` — використовуй `waitForAny`.
+- Максимум відкладених `await nap(…)` — використовуй `waitForAny`.
 
 ## Перевірка перед комітом
 - `node postThreads.js --action=post --type=tip`

--- a/actions/search.follow.js
+++ b/actions/search.follow.js
@@ -1,7 +1,7 @@
 // actions/search.follow.js
 import { ensureThreadsReady } from '../core/login.js';
 import { isOnThreadsFeed } from '../core/feed.js';
-import { waitForAny, clickAny } from '../utils.js';
+import { waitForAny, clickAny, nap } from '../utils.js';
 import { tryStep } from '../helpers/misc.js';
 
 /**
@@ -46,7 +46,7 @@ export async function run(page, {
             await input.click({ clickCount: 3 }).catch(() => { });
             await input.type(q, { delay: 25 });
             await page.keyboard.press('Enter');
-            await page.waitForTimeout(1200);
+            await nap(1200);
 
             const opened = await clickAny(page, [
                 'a[href*="/@"]',
@@ -58,7 +58,7 @@ export async function run(page, {
             const toLike = Math.max(minL, Math.min(maxL, minL + Math.floor(Math.random() * (maxL - minL + 1))));
             for (let i = 0; i < toLike; i++) {
                 await page.evaluate(() => window.scrollBy({ top: window.innerHeight * 0.8, behavior: 'smooth' }));
-                await page.waitForTimeout(600);
+                await nap(600);
                 try {
                     await page.evaluate(() => {
                         const btn = document.querySelector('[aria-label="Подобається"], [aria-label="Like"]');
@@ -76,7 +76,7 @@ export async function run(page, {
             if (followed) follows++;
 
             await page.goBack({ waitUntil: 'domcontentloaded' }).catch(() => { });
-            await page.waitForTimeout(600);
+            await nap(600);
             await page.goto('https://www.threads.com/', { waitUntil: 'domcontentloaded' }).catch(() => { });
         }, { page, context: { query: q } });
     }

--- a/coach/coachAgent.js
+++ b/coach/coachAgent.js
@@ -1,6 +1,7 @@
 // coach/coachAgent.js
 // Інтеграція з ChatGPT (Chat Completions) + виконання команд на сторінці.
 import { logStep, logError, appendCoachSolution } from "../helpers/logger.js";
+import { nap } from "../utils.js";
 
 const COACH_MODEL = process.env.COACH_MODEL || "gpt-4o-mini";
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
@@ -119,7 +120,7 @@ async function executePlanOnPage(page, plan) {
                 await page.type(act.selector, act.text || "", { delay: 10 });
                 r.ok = true;
             } else if (act.type === "wait") {
-                await page.waitForTimeout(act.timeoutMs || 500);
+                await nap(act.timeoutMs || 500);
                 r.ok = true;
             } else {
                 throw new Error("unknown action or missing selector");

--- a/core/feed.js
+++ b/core/feed.js
@@ -1,5 +1,5 @@
 // core/feed.js
-import { waitForAny, screenshotStep } from '../utils.js';
+import { waitForAny, screenshotStep, nap } from '../utils.js';
 import { THREADS_PROFILE_LINK, THREADS_COMPOSER_ANY } from '../constants/selectors.js';
 
 export async function isOnThreadsFeed(page, expectedUser) {
@@ -34,7 +34,7 @@ export async function scrollAndReact(page, {
 
     for (let r = 0; r < rounds; r++) {
         await page.evaluate(() => window.scrollBy({ top: window.innerHeight * 0.9, behavior: 'smooth' }));
-        await page.waitForTimeout(pause);
+        await nap(pause);
 
         // знайдемо видимі пости та їхні кнопки
         const posts = await page.evaluate(() => {
@@ -90,14 +90,14 @@ export async function scrollAndReact(page, {
                             }
                         }
                     }, { text: p.text, reply });
-                    await page.waitForTimeout(300);
+                    await nap(300);
 
                     const replyBox = await page.$('textarea, div[contenteditable="true"]');
                     if (replyBox) {
                         await replyBox.type(reply, { delay: 10 });
                         await page.keyboard.press('Enter');
                         reacted.commented++;
-                        await page.waitForTimeout(300);
+                        await nap(300);
                     }
                 } catch { }
             }

--- a/core/login.js
+++ b/core/login.js
@@ -136,7 +136,7 @@ async function fillThreadsLoginForm(page, user, pass) {
         el.dataset.prevOutline = el.style.outline || '';
         el.style.outline = '3px solid red';
     }, loginBtn);
-    await page.waitForTimeout(2000);
+    await sleep(2000);
     await Promise.all([
         page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 45000 }).catch(() => { }),
 


### PR DESCRIPTION
## Summary
- use `nap` helper instead of removed `page.waitForTimeout`
- update maintainer guide to reflect new delay approach

## Testing
- `npm test`
- `node postThreads.js --action=post --type=tip` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `node postThreads.js --action=find-entrepreneurs --maxFollows=3` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `node postThreads.js --action=feed-scan --commentMax=3 --scanScrolls=50` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `node runners/threads.js --action=login.test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b622dd48bc83328d5bf212e6e2a58c