### PR TITLE
refactor: wait for login inputs

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -96,11 +96,18 @@ async function fillThreadsLoginForm(page, user, pass) {
     const pSel = THREADS_LOGIN_PASS_INPUT;
     const sSel = THREADS_LOGIN_SUBMIT;
     console.log('[fillThreadsLoginForm] selectors', { uSel, pSel, sSel });
-    const u = await page.$(uSel).catch(() => null);
-    const p = await page.$(pSel).catch(() => null);
+    const timeout = 10000;
+    const u = await page.waitForSelector(uSel, { timeout }).catch(e => {
+        logError(`[fillThreadsLoginForm] wait for user input failed: ${e?.message}`);
+        return null;
+    });
+    const p = await page.waitForSelector(pSel, { timeout }).catch(e => {
+        logError(`[fillThreadsLoginForm] wait for pass input failed: ${e?.message}`);
+        return null;
+    });
     console.log('[fillThreadsLoginForm] inputs found', { u: !!u, p: !!p });
     if (!u || !p) {
-        console.log('[fillThreadsLoginForm] missing input element');
+        logError('[fillThreadsLoginForm] missing input element');
         return false;
     }
 


### PR DESCRIPTION
## Summary
- ensure Threads login inputs wait for visibility with a timeout
- log failures when login fields can't be found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f6ddc3a88332bf13f931fe21d9bb