### PR TITLE
feat: fallback Threads login via API

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -160,6 +160,34 @@ async function fillThreadsLoginForm(page, user, pass) {
     return true;
 }
 
+async function loginViaApi(page, user, pass) {
+    try {
+        const res = await page.evaluate(async ({ user, pass }) => {
+            try {
+                const enc = window.require("InstagramPasswordEncryption");
+                const api = window.require("BarcelonaLoginAPI");
+                const resp = await api.login({
+                    username: user,
+                    password: pass,
+                    encryptionKeyId: enc.key_id,
+                    encryptionPublicKey: enc.public_key,
+                    encryptionVersion: enc.version,
+                    skipLogin: false,
+                    next: null,
+                    canThreadsSignUpWithIG: true,
+                });
+                return resp?.json;
+            } catch (err) {
+                return { error: err?.message };
+            }
+        }, { user, pass });
+        return res;
+    } catch (e) {
+        logError(`[loginViaApi] ${e?.message}`);
+        return null;
+    }
+}
+
 
 
 export async function ensureThreadsReady(page, opts = {}) {
@@ -196,6 +224,16 @@ export async function ensureThreadsReady(page, opts = {}) {
         logStep("URL все ще /login, повторюю вхід");
         await tryStep("threads login retry", () => fillThreadsLoginForm(page, threadsUser, threadsPass), { page });
         await sleep(1000);
+    }
+
+    if ((page.url() || "").includes("/login")) {
+        logStep("Спроба API логіну");
+        const apiRes = await tryStep("threads api login", () => loginViaApi(page, threadsUser, threadsPass), { page });
+        if (apiRes?.authenticated) {
+            const redirect = apiRes.redirect_uri || 'https://www.threads.net/';
+            await tryStep("api login redirect", () => retry(() => page.goto(redirect, { waitUntil: "domcontentloaded", timeout: 30000 })), { page });
+            await sleep(1000);
+        }
     }
 
     await tryStep("Очікую завантаження фіду Threads…", () => waitUrlNot(page, "/login", 45000), { page });


### PR DESCRIPTION
## Summary
- add `loginViaApi` helper to call Threads' `BarcelonaLoginAPI` with encrypted password
- invoke API-based login if the normal form submission keeps us on `/login`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f5f1dd5c83329bb52aff906a71da