### PR TITLE
refactor: clear login inputs without keyboard

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -104,16 +104,10 @@ async function fillThreadsLoginForm(page, user, pass) {
         return false;
     }
 
-    await page.focus(uSel).catch(() => { });
-    await page.keyboard.down('Control').catch(() => { });
-    await page.keyboard.press('A').catch(() => { });
-    await page.keyboard.up('Control').catch(() => { });
+    await page.$eval(uSel, el => el.value = '').catch(() => { });
     await page.type(uSel, user, { delay: 20 }).catch(() => { });
 
-    await page.focus(pSel).catch(() => { });
-    await page.keyboard.down('Control').catch(() => { });
-    await page.keyboard.press('A').catch(() => { });
-    await page.keyboard.up('Control').catch(() => { });
+    await page.$eval(pSel, el => el.value = '').catch(() => { });
     await page.type(pSel, pass, { delay: 20 }).catch(() => { });
 
     await takeShot(page, 'threads_login_filled');


### PR DESCRIPTION
## Summary
- Clear login and password inputs via `page.$eval` before typing
- Remove unnecessary `page.keyboard` usage in login flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f6defe0c8332acb442e85555b33a