### PR TITLE
feat: add CSS/XPath click helper

### DIFF
--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -3,6 +3,7 @@
 export {
     waitForAny,
     clickAny,
+    clickCssOrXPath,
     clickByText,
     clickByPartialText,
     typeLikeHuman

--- a/test/clickCssOrXPath.test.js
+++ b/test/clickCssOrXPath.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'assert/strict';
+import { clickCssOrXPath } from '../utils.js';
+
+test('clickCssOrXPath clicks via CSS when available', async () => {
+  let clicked = false;
+  const handle = { click: async () => { clicked = true; } };
+  const page = {
+    waitForSelector: async () => handle,
+    $x: async () => { throw new Error('should not use XPath'); }
+  };
+  const ok = await clickCssOrXPath(page, ['.one', '.two'], '//div');
+  assert.equal(ok, true);
+  assert.equal(clicked, true);
+});
+
+test('clickCssOrXPath falls back to XPath', async () => {
+  let cssTried = false;
+  let xpathTried = false;
+  let clicked = false;
+  const handle = { click: async () => { clicked = true; } };
+  const page = {
+    waitForSelector: async () => { cssTried = true; throw new Error('not found'); },
+    $x: async () => { xpathTried = true; return [handle]; }
+  };
+  const ok = await clickCssOrXPath(page, ['.missing'], '//span');
+  assert.equal(ok, true);
+  assert.equal(cssTried, true);
+  assert.equal(xpathTried, true);
+  assert.equal(clicked, true);
+});


### PR DESCRIPTION
## Summary
- add clickCssOrXPath utility to try CSS then XPath and click element handle
- re-export clickCssOrXPath from helpers/dom.js
- cover new helper with node tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f6e7837c83328b3d0bce57d472f0