### PR TITLE
Allow overriding Threads credentials in login

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -163,7 +163,7 @@ async function fillThreadsLoginForm(page, user, pass) {
 
 
 export async function ensureThreadsReady(page, opts = {}) {
-    const { user: threadsUser, pass: threadsPass } = getThreadsCreds();
+    const { user: threadsUser, pass: threadsPass } = { ...getThreadsCreds(), ...opts };
 
     page.setDefaultTimeout(20000);
     page.setDefaultNavigationTimeout(30000);


### PR DESCRIPTION
## Summary
- Merge passed options with default Thread credentials in `ensureThreadsReady`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6fadde1d08332a536ecd556c50e8e